### PR TITLE
Includes deployment step only on push not on pull requests

### DIFF
--- a/.github/workflows/development_workflow.yml
+++ b/.github/workflows/development_workflow.yml
@@ -77,6 +77,7 @@ jobs:
         HUEB_SECRET_KEY: ${{ secrets.HUEB_SECRET_KEY }}
 
   StagingDeployment:
+    if: ${{ github.event_name == 'push' }}
     needs: [Tests, flake8, black]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The staging deployment step is currently executed whenever we push to the development branch or when a PR is created. 
This wasn't as dangerous as it seems to be, because we only deploy the current head of the development branch. So no bad code could be deployed by exploiting this loophole